### PR TITLE
Add sanitized Tron raw payload to reputation response

### DIFF
--- a/docs/mvp_api_reference.md
+++ b/docs/mvp_api_reference.md
@@ -92,11 +92,19 @@ the value supplied when running `./start.sh`.
       "recent_in": 5,
       "recent_out": 10,
       "trc20_tokens": 2
+    },
+    "raw": {
+      "totalTransactionCount": 1200,
+      "balance": "250000000000",
+      "transactions_in": [...],
+      "transactions_out": [...],
+      "trc20token_balances": [...]
     }
   }
   ```
-- **Notes**: The raw TronScan payload is included in the response for forensic
-  follow-ups, and HTTP timeouts are capped at 12 seconds by default.
+- **Notes**: The raw TronScan payload is returned under `raw` with sensitive
+  fields (such as private keys or secrets) removed to avoid leaking credentials.
+  HTTP timeouts are capped at 12 seconds by default.
 
 ## Health endpoint
 - **`GET /healthz`** returns service status along with the sanctions dataset

--- a/tests/test_screening_service.py
+++ b/tests/test_screening_service.py
@@ -249,6 +249,8 @@ def test_tron_reputation(client):
             "transactions_in": [{}] * 5,
             "transactions_out": [{}] * 10,
             "trc20token_balances": [{"amount": 150000}],
+            "privateKey": "super-secret",
+            "ownerPermission": {"keys": [{"address": "abc", "privateKey": "hidden"}]},
         },
     )
     response = client.post(
@@ -260,6 +262,10 @@ def test_tron_reputation(client):
     data = response.json()
     assert data["risk"] == "medium"
     assert data["stats"]["transaction_count"] == 1200
+    assert data["raw"]["totalTransactionCount"] == 1200
+    assert "privateKey" not in data["raw"]
+    assert data["raw"]["ownerPermission"]["keys"][0]["address"] == "abc"
+    assert "privateKey" not in data["raw"]["ownerPermission"]["keys"][0]
 
 
 def test_sanctions_search_filters_by_dob(monkeypatch, httpx_mock, tmp_path):


### PR DESCRIPTION
## Summary
- include the TronScan raw payload in the /tron/reputation response
- redact sensitive keys from the raw payload before returning it
- update tests and documentation for the new raw field

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e4aa0a861c832c9f16f58c6b6cc506